### PR TITLE
Consider $step_sec when calculating number of columns

### DIFF
--- a/trace2heatmap.pl
+++ b/trace2heatmap.pl
@@ -221,7 +221,7 @@ foreach my $line (@lines) {
 	$largest_latency = $latency if $latency > $largest_latency;
 }
 debug "Input start/end times: $start_time/$end_time\n";
-if ((($end_time - $start_time) / $timefactor) > $limit_col) {
+if ((($end_time - $start_time) / $timefactor / $step_sec) > $limit_col) {
 	die "Too many columns (>$limit_col); try setting --unitstime ?";
 }
 $max_lat ||= $largest_latency;


### PR DESCRIPTION
The $step_sec factor is used in the code when deciding which column a datapoint belongs in, but not when calculating the total number of columns for comparing to the max number of columns.
